### PR TITLE
Required changes for the repo rename

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -7,8 +7,8 @@ import (
 	"os"
 	"runtime"
 
-	"github.com/monstorak/monstorak/pkg/apis"
-	"github.com/monstorak/monstorak/pkg/controller"
+	"github.com/monstorak/monstorak-operator/pkg/apis"
+	"github.com/monstorak/monstorak-operator/pkg/controller"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/pkg/apis/addtoscheme_alerts_v1alpha1.go
+++ b/pkg/apis/addtoscheme_alerts_v1alpha1.go
@@ -1,7 +1,7 @@
 package apis
 
 import (
-	"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1"
+	"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1"
 )
 
 func init() {

--- a/pkg/apis/alerts/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/alerts/v1alpha1/zz_generated.openapi.go
@@ -13,11 +13,11 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.PrometheusSpec":     schema_pkg_apis_alerts_v1alpha1_PrometheusSpec(ref),
-		"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlert":       schema_pkg_apis_alerts_v1alpha1_StorageAlert(ref),
-		"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlertSpec":   schema_pkg_apis_alerts_v1alpha1_StorageAlertSpec(ref),
-		"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlertStatus": schema_pkg_apis_alerts_v1alpha1_StorageAlertStatus(ref),
-		"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageSpec":        schema_pkg_apis_alerts_v1alpha1_StorageSpec(ref),
+		"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.PrometheusSpec":     schema_pkg_apis_alerts_v1alpha1_PrometheusSpec(ref),
+		"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlert":       schema_pkg_apis_alerts_v1alpha1_StorageAlert(ref),
+		"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlertSpec":   schema_pkg_apis_alerts_v1alpha1_StorageAlertSpec(ref),
+		"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlertStatus": schema_pkg_apis_alerts_v1alpha1_StorageAlertStatus(ref),
+		"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageSpec":        schema_pkg_apis_alerts_v1alpha1_StorageSpec(ref),
 	}
 }
 
@@ -80,19 +80,19 @@ func schema_pkg_apis_alerts_v1alpha1_StorageAlert(ref common.ReferenceCallback) 
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlertSpec"),
+							Ref: ref("github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlertSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlertStatus"),
+							Ref: ref("github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlertStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlertSpec", "github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageAlertStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlertSpec", "github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageAlertStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -108,7 +108,7 @@ func schema_pkg_apis_alerts_v1alpha1_StorageAlertSpec(ref common.ReferenceCallba
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageSpec"),
+										Ref: ref("github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageSpec"),
 									},
 								},
 							},
@@ -116,14 +116,14 @@ func schema_pkg_apis_alerts_v1alpha1_StorageAlertSpec(ref common.ReferenceCallba
 					},
 					"prometheus": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.PrometheusSpec"),
+							Ref: ref("github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.PrometheusSpec"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.PrometheusSpec", "github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1.StorageSpec"},
+			"github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.PrometheusSpec", "github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1.StorageSpec"},
 	}
 }
 

--- a/pkg/controller/add_storagealert.go
+++ b/pkg/controller/add_storagealert.go
@@ -1,7 +1,7 @@
 package controller
 
 import (
-	"github.com/monstorak/monstorak/pkg/controller/storagealert"
+	"github.com/monstorak/monstorak-operator/pkg/controller/storagealert"
 )
 
 func init() {

--- a/pkg/controller/storagealert/storagealert_controller.go
+++ b/pkg/controller/storagealert/storagealert_controller.go
@@ -6,9 +6,9 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
-	"github.com/monstorak/monstorak/pkg/tasks"
+	"github.com/monstorak/monstorak-operator/pkg/tasks"
 
-	alertsv1alpha1 "github.com/monstorak/monstorak/pkg/apis/alerts/v1alpha1"
+	alertsv1alpha1 "github.com/monstorak/monstorak-operator/pkg/apis/alerts/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/tasks/prerequisites.go
+++ b/pkg/tasks/prerequisites.go
@@ -1,8 +1,8 @@
 package tasks
 
 import (
-	"github.com/monstorak/monstorak/pkg/common"
-	"github.com/monstorak/monstorak/pkg/prometheus"
+	"github.com/monstorak/monstorak-operator/pkg/common"
+	"github.com/monstorak/monstorak-operator/pkg/prometheus"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 

--- a/pkg/tasks/prometheus.go
+++ b/pkg/tasks/prometheus.go
@@ -2,8 +2,8 @@ package tasks
 
 import (
 	monv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/monstorak/monstorak/pkg/manifests"
-	"github.com/monstorak/monstorak/pkg/prometheus"
+	"github.com/monstorak/monstorak-operator/pkg/manifests"
+	"github.com/monstorak/monstorak-operator/pkg/prometheus"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 )
 


### PR DESCRIPTION
Changed all the import lines from,
'github.com/monstorak/monstorak/' to 'github.com/monstorak/monstorak-operator'
in order to reflect the github repo name change.

Signed-off-by: aruniiird <arun.iiird@gmail.com>